### PR TITLE
[Create] Firebase Auth 가입 & DB 닉네임 저장 기능 구현 & Constants.swift 추가

### DIFF
--- a/QuoteDev/QuoteDev.xcodeproj/project.pbxproj
+++ b/QuoteDev/QuoteDev.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0D9613E5ECE9BF130E2281FD /* Pods_QuoteDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CB8A73D6F930854930511EE /* Pods_QuoteDev.framework */; };
 		4C903C711F6A5D0D003ECEA4 /* BoardDev.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4C903C701F6A5D0D003ECEA4 /* BoardDev.storyboard */; };
 		4C903C731F6A5D17003ECEA4 /* BoardDevMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C903C721F6A5D17003ECEA4 /* BoardDevMainViewController.swift */; };
+		FE15F6B91F72602C008E9A42 /* DataCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE15F6B81F72602C008E9A42 /* DataCenter.swift */; };
 		FE7EC3961F6A4E1000696041 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7EC3951F6A4E1000696041 /* AppDelegate.swift */; };
 		FE7EC3981F6A4E1000696041 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7EC3971F6A4E1000696041 /* MainViewController.swift */; };
 		FE7EC39B1F6A4E1000696041 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FE7EC3991F6A4E1000696041 /* Main.storyboard */; };
@@ -25,6 +26,7 @@
 		4CB8A73D6F930854930511EE /* Pods_QuoteDev.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuoteDev.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BFF089C886F6B71AA3380D1 /* Pods-QuoteDev.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuoteDev.debug.xcconfig"; path = "Pods/Target Support Files/Pods-QuoteDev/Pods-QuoteDev.debug.xcconfig"; sourceTree = "<group>"; };
 		5FC370CABF19E04A9D982688 /* Pods-QuoteDev.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuoteDev.release.xcconfig"; path = "Pods/Target Support Files/Pods-QuoteDev/Pods-QuoteDev.release.xcconfig"; sourceTree = "<group>"; };
+		FE15F6B81F72602C008E9A42 /* DataCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCenter.swift; sourceTree = "<group>"; };
 		FE7EC3921F6A4E1000696041 /* QuoteDev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuoteDev.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE7EC3951F6A4E1000696041 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FE7EC3971F6A4E1000696041 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -89,6 +91,7 @@
 				FE7EC39E1F6A4E1000696041 /* LaunchScreen.storyboard */,
 				FE7EC3991F6A4E1000696041 /* Main.storyboard */,
 				FE7EC3951F6A4E1000696041 /* AppDelegate.swift */,
+				FE15F6B81F72602C008E9A42 /* DataCenter.swift */,
 				FE7EC3971F6A4E1000696041 /* MainViewController.swift */,
 				FE7EC3AE1F6A555400696041 /* SettingView */,
 				FE7EC3A91F6A536300696041 /* BoardDev */,
@@ -256,6 +259,7 @@
 			files = (
 				FE7EC3B01F6A557300696041 /* SettingMainViewController.swift in Sources */,
 				FE7EC3981F6A4E1000696041 /* MainViewController.swift in Sources */,
+				FE15F6B91F72602C008E9A42 /* DataCenter.swift in Sources */,
 				4C903C731F6A5D17003ECEA4 /* BoardDevMainViewController.swift in Sources */,
 				FE7EC3961F6A4E1000696041 /* AppDelegate.swift in Sources */,
 			);

--- a/QuoteDev/QuoteDev.xcodeproj/project.pbxproj
+++ b/QuoteDev/QuoteDev.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		4C903C711F6A5D0D003ECEA4 /* BoardDev.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4C903C701F6A5D0D003ECEA4 /* BoardDev.storyboard */; };
 		4C903C731F6A5D17003ECEA4 /* BoardDevMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C903C721F6A5D17003ECEA4 /* BoardDevMainViewController.swift */; };
 		FE15F6B91F72602C008E9A42 /* DataCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE15F6B81F72602C008E9A42 /* DataCenter.swift */; };
+		FE15F6BB1F726A41008E9A42 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE15F6BA1F726A41008E9A42 /* Constants.swift */; };
+		FE15F6BD1F726F85008E9A42 /* QuoteCommentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE15F6BC1F726F85008E9A42 /* QuoteCommentViewController.swift */; };
 		FE7EC3961F6A4E1000696041 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7EC3951F6A4E1000696041 /* AppDelegate.swift */; };
 		FE7EC3981F6A4E1000696041 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7EC3971F6A4E1000696041 /* MainViewController.swift */; };
 		FE7EC39B1F6A4E1000696041 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FE7EC3991F6A4E1000696041 /* Main.storyboard */; };
@@ -27,6 +29,8 @@
 		5BFF089C886F6B71AA3380D1 /* Pods-QuoteDev.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuoteDev.debug.xcconfig"; path = "Pods/Target Support Files/Pods-QuoteDev/Pods-QuoteDev.debug.xcconfig"; sourceTree = "<group>"; };
 		5FC370CABF19E04A9D982688 /* Pods-QuoteDev.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuoteDev.release.xcconfig"; path = "Pods/Target Support Files/Pods-QuoteDev/Pods-QuoteDev.release.xcconfig"; sourceTree = "<group>"; };
 		FE15F6B81F72602C008E9A42 /* DataCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCenter.swift; sourceTree = "<group>"; };
+		FE15F6BA1F726A41008E9A42 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		FE15F6BC1F726F85008E9A42 /* QuoteCommentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuoteCommentViewController.swift; sourceTree = "<group>"; };
 		FE7EC3921F6A4E1000696041 /* QuoteDev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuoteDev.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE7EC3951F6A4E1000696041 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FE7EC3971F6A4E1000696041 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -91,8 +95,10 @@
 				FE7EC39E1F6A4E1000696041 /* LaunchScreen.storyboard */,
 				FE7EC3991F6A4E1000696041 /* Main.storyboard */,
 				FE7EC3951F6A4E1000696041 /* AppDelegate.swift */,
+				FE15F6BA1F726A41008E9A42 /* Constants.swift */,
 				FE15F6B81F72602C008E9A42 /* DataCenter.swift */,
 				FE7EC3971F6A4E1000696041 /* MainViewController.swift */,
+				FE15F6BC1F726F85008E9A42 /* QuoteCommentViewController.swift */,
 				FE7EC3AE1F6A555400696041 /* SettingView */,
 				FE7EC3A91F6A536300696041 /* BoardDev */,
 				FE7EC39C1F6A4E1000696041 /* Assets.xcassets */,
@@ -259,9 +265,11 @@
 			files = (
 				FE7EC3B01F6A557300696041 /* SettingMainViewController.swift in Sources */,
 				FE7EC3981F6A4E1000696041 /* MainViewController.swift in Sources */,
+				FE15F6BD1F726F85008E9A42 /* QuoteCommentViewController.swift in Sources */,
 				FE15F6B91F72602C008E9A42 /* DataCenter.swift in Sources */,
 				4C903C731F6A5D17003ECEA4 /* BoardDevMainViewController.swift in Sources */,
 				FE7EC3961F6A4E1000696041 /* AppDelegate.swift in Sources */,
+				FE15F6BB1F726A41008E9A42 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/QuoteDev/QuoteDev/AppDelegate.swift
+++ b/QuoteDev/QuoteDev/AppDelegate.swift
@@ -9,8 +9,6 @@
 import UIKit
 import Firebase
 
-let userUid:String = "firebaseUserUid"
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -23,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // UserDefaults에 저장된 uid가 없을 경우, Firebase의 Auth signInAnonymously을 진행합니다.
         // Firebase의 익명 Auth는 앱을 지웠다 설치하더라도 같은 uid를 갖습니다. ( 디바이스 의존성 )
-        if UserDefaults.standard.string(forKey: userUid) == nil {
+        if UserDefaults.standard.string(forKey: userDefaultsUid) == nil {
             Auth.auth().signInAnonymously { (user, error) in
                 print("///// signInAnonymously user: ", user ?? "no user")
                 print("///// signInAnonymously user uid: ", user?.uid ?? "no user uid")
@@ -31,11 +29,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 
                 // SignIn 후, UserDefaults에 저장합니다.
                 guard let uid = user?.uid else { return }
-                UserDefaults.standard.set(uid, forKey: userUid)
+                UserDefaults.standard.set(uid, forKey: userDefaultsUid)
             }
         }
         
-        print("///// userDefaults uid: ", UserDefaults.standard.string(forKey: userUid) ?? "no data")
+        print("///// userDefaults uid: ", UserDefaults.standard.string(forKey: userDefaultsUid) ?? "no data")
         
         return true
     }

--- a/QuoteDev/QuoteDev/AppDelegate.swift
+++ b/QuoteDev/QuoteDev/AppDelegate.swift
@@ -9,6 +9,8 @@
 import UIKit
 import Firebase
 
+let userUid:String = "firebaseUserUid"
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -16,9 +18,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         
         FirebaseApp.configure()
+        
+        // UserDefaults에 저장된 uid가 없을 경우, Firebase의 Auth signInAnonymously을 진행합니다.
+        // Firebase의 익명 Auth는 앱을 지웠다 설치하더라도 같은 uid를 갖습니다. ( 디바이스 의존성 )
+        if UserDefaults.standard.string(forKey: userUid) == nil {
+            Auth.auth().signInAnonymously { (user, error) in
+                print("///// signInAnonymously user: ", user ?? "no user")
+                print("///// signInAnonymously user uid: ", user?.uid ?? "no user uid")
+                print("///// signInAnonymously error: ", error ?? "no error")
+                
+                // SignIn 후, UserDefaults에 저장합니다.
+                guard let uid = user?.uid else { return }
+                UserDefaults.standard.set(uid, forKey: userUid)
+            }
+        }
+        
+        print("///// userDefaults uid: ", UserDefaults.standard.string(forKey: userUid) ?? "no data")
         
         return true
     }

--- a/QuoteDev/QuoteDev/AppDelegate.swift
+++ b/QuoteDev/QuoteDev/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // UserDefaults에 저장된 uid가 없을 경우, Firebase의 Auth signInAnonymously을 진행합니다.
         // Firebase의 익명 Auth는 앱을 지웠다 설치하더라도 같은 uid를 갖습니다. ( 디바이스 의존성 )
-        if UserDefaults.standard.string(forKey: userDefaultsUid) == nil {
+        if UserDefaults.standard.string(forKey: Constants.userDefaults_Uid) == nil {
             Auth.auth().signInAnonymously { (user, error) in
                 print("///// signInAnonymously user: ", user ?? "no user")
                 print("///// signInAnonymously user uid: ", user?.uid ?? "no user uid")
@@ -29,11 +29,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 
                 // SignIn 후, UserDefaults에 저장합니다.
                 guard let uid = user?.uid else { return }
-                UserDefaults.standard.set(uid, forKey: userDefaultsUid)
+                UserDefaults.standard.set(uid, forKey: Constants.userDefaults_Uid)
             }
         }
         
-        print("///// userDefaults uid: ", UserDefaults.standard.string(forKey: userDefaultsUid) ?? "no data")
+        print("///// userDefaults uid: ", UserDefaults.standard.string(forKey: Constants.userDefaults_Uid) ?? "no data")
         
         return true
     }

--- a/QuoteDev/QuoteDev/Base.lproj/Main.storyboard
+++ b/QuoteDev/QuoteDev/Base.lproj/Main.storyboard
@@ -34,7 +34,7 @@
                                 <state key="normal" title="Comment"/>
                                 <connections>
                                     <action selector="buttonCommentAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cPa-Xr-Zmk"/>
-                                    <segue destination="xuP-7E-1r0" kind="show" id="J83-tE-FIT"/>
+                                    <segue destination="xuP-7E-1r0" kind="show" id="l6l-aX-3MD"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o7W-tp-Ucm">
@@ -72,10 +72,10 @@
             </objects>
             <point key="canvasLocation" x="1076" y="111.99400299850076"/>
         </scene>
-        <!--View Controller-->
+        <!--Quote Comment View Controller-->
         <scene sceneID="A7W-fM-qCV">
             <objects>
-                <viewController id="xuP-7E-1r0" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="QuoteCommentViewController" id="xuP-7E-1r0" customClass="QuoteCommentViewController" customModule="QuoteDev" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="TwH-67-fy2"/>
                         <viewControllerLayoutGuide type="bottom" id="ZnW-cA-lWd"/>

--- a/QuoteDev/QuoteDev/Base.lproj/Main.storyboard
+++ b/QuoteDev/QuoteDev/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="oKe-I4-C5j">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="oKe-I4-C5j">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -37,10 +37,10 @@
             </objects>
             <point key="canvasLocation" x="1076" y="111.99400299850076"/>
         </scene>
-        <!--GSBoardDev-->
+        <!--BoardDev-->
         <scene sceneID="D4X-z7-6T2">
             <objects>
-                <viewControllerPlaceholder storyboardName="GSBoardDev" id="bm6-J3-KyO" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardName="BoardDev" id="bm6-J3-KyO" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dRe-P0-HCt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1703.2" y="111.54422788605699"/>

--- a/QuoteDev/QuoteDev/Base.lproj/Main.storyboard
+++ b/QuoteDev/QuoteDev/Base.lproj/Main.storyboard
@@ -28,14 +28,76 @@
                                     <segue destination="bm6-J3-KyO" kind="show" id="9Sb-QW-G54"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jWz-e1-3yB">
+                                <rect key="frame" x="88" y="318" width="67" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Comment"/>
+                                <connections>
+                                    <action selector="buttonCommentAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="cPa-Xr-Zmk"/>
+                                    <segue destination="xuP-7E-1r0" kind="show" id="J83-tE-FIT"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o7W-tp-Ucm">
+                                <rect key="frame" x="16" y="318" width="30" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Like"/>
+                                <connections>
+                                    <action selector="buttonLikeAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bb1-hb-J8M"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ePi-uF-1cj">
+                                <rect key="frame" x="54" y="322" width="21" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="00" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wri-90-8nP">
+                                <rect key="frame" x="163" y="323" width="21" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <navigationItem key="navigationItem" id="uDr-hl-T2w"/>
+                    <connections>
+                        <outlet property="buttonComment" destination="jWz-e1-3yB" id="Bem-bo-cMp"/>
+                        <outlet property="buttonLike" destination="o7W-tp-Ucm" id="7DI-vT-iic"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1076" y="111.99400299850076"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="A7W-fM-qCV">
+            <objects>
+                <viewController id="xuP-7E-1r0" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="TwH-67-fy2"/>
+                        <viewControllerLayoutGuide type="bottom" id="ZnW-cA-lWd"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="iL7-LY-yOf">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="QuoteCommentViewController" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u15-f3-N8N">
+                                <rect key="frame" x="70" y="323" width="234" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="oK2-ER-HZR" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1886" y="112"/>
         </scene>
         <!--BoardDev-->
         <scene sceneID="D4X-z7-6T2">
@@ -43,7 +105,7 @@
                 <viewControllerPlaceholder storyboardName="BoardDev" id="bm6-J3-KyO" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dRe-P0-HCt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1703.2" y="111.54422788605699"/>
+            <point key="canvasLocation" x="1075" y="572"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="Uf7-12-fiP">

--- a/QuoteDev/QuoteDev/Constants.swift
+++ b/QuoteDev/QuoteDev/Constants.swift
@@ -1,0 +1,21 @@
+//
+//  Constants.swift
+//  QuoteDev
+//
+//  Created by leejaesung on 2017. 9. 20..
+//  Copyright © 2017년 leejaesung. All rights reserved.
+//
+
+import Foundation
+
+struct Constants {
+    static let userDefaults_Uid:String = "firebaseUserUid"       // UserDefaults에 저장하는 Uid의 UserDefaults Key값입니다.
+    static let userDefaults_UserNickname:String = "userNickname" //
+    
+    static let quoteCommentViewController:String = "QuoteCommentViewController"
+    
+    static let firebaseUsersRoot:String = "Users"
+    static let firebaseUserUid:String = "userUid"
+    static let firebaseUserNickname:String = "userNickname"
+}
+

--- a/QuoteDev/QuoteDev/DataCenter.swift
+++ b/QuoteDev/QuoteDev/DataCenter.swift
@@ -1,0 +1,20 @@
+//
+//  DataCenter.swift
+//  QuoteDev
+//
+//  Created by leejaesung on 2017. 9. 20..
+//  Copyright © 2017년 leejaesung. All rights reserved.
+//
+
+import Foundation
+
+// UserDefaults에 저장하는 Uid의 UserDefaults Key값입니다.
+let userDefaultsUid:String = "firebaseUserUid"
+
+
+// 추후 사용할 DataCenter 입니다.
+class DataCenter {
+    
+    static let sharedInstance = DataCenter()
+    
+}

--- a/QuoteDev/QuoteDev/DataCenter.swift
+++ b/QuoteDev/QuoteDev/DataCenter.swift
@@ -8,9 +8,6 @@
 
 import Foundation
 
-// UserDefaults에 저장하는 Uid의 UserDefaults Key값입니다.
-let userDefaultsUid:String = "firebaseUserUid"
-
 
 // 추후 사용할 DataCenter 입니다.
 class DataCenter {

--- a/QuoteDev/QuoteDev/MainViewController.swift
+++ b/QuoteDev/QuoteDev/MainViewController.swift
@@ -9,6 +9,9 @@
 import UIKit
 
 class MainViewController: UIViewController {
+    
+    @IBOutlet var buttonLike : UIButton! //명언 좋아요 버튼
+    @IBOutlet var buttonComment : UIButton! //명언 댓글 버튼
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -19,7 +22,29 @@ class MainViewController: UIViewController {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
+    
+    
+    // MARK: 명언 좋아요 버튼 액션
+    @IBAction func buttonLikeAction(_ sender: UIButton) {
+        
+    }
 
+    // MARK: 명언 댓글 버튼 액션
+    @IBAction func buttonCommentAction(_ sender: UIButton) {
+        
+        let alertSetUserNickname:UIAlertController = UIAlertController(title: "닉네임 설정", message: "닉네임을 설정해주세요.", preferredStyle: .alert)
+        
+        alertSetUserNickname.addTextField { (textField) in
+            textField.placeholder = "스티브 잡스"
+        }
+        
+        alertSetUserNickname.addAction(UIAlertAction(title: "OK", style: .default, handler: { [weak alertSetUserNickname] (_) in
+            let textField = alertSetUserNickname!.textFields![0] // 위에서 추가한 텍스트필드이므로 옵셔널 바인딩은 스킵.
+            print("///// textField: ", textField.text ?? "(no data)")
+        }))
+        
+        self.present(alertSetUserNickname, animated: true, completion: nil)
+    }
 
 }
 

--- a/QuoteDev/QuoteDev/MainViewController.swift
+++ b/QuoteDev/QuoteDev/MainViewController.swift
@@ -7,17 +7,18 @@
 //
 
 import UIKit
+import Firebase
 
 class MainViewController: UIViewController {
     
     @IBOutlet var buttonLike : UIButton! //명언 좋아요 버튼
     @IBOutlet var buttonComment : UIButton! //명언 댓글 버튼
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
     }
-
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
@@ -28,23 +29,52 @@ class MainViewController: UIViewController {
     @IBAction func buttonLikeAction(_ sender: UIButton) {
         
     }
-
+    
     // MARK: 명언 댓글 버튼 액션
     @IBAction func buttonCommentAction(_ sender: UIButton) {
         
-        let alertSetUserNickname:UIAlertController = UIAlertController(title: "닉네임 설정", message: "닉네임을 설정해주세요.", preferredStyle: .alert)
-        
-        alertSetUserNickname.addTextField { (textField) in
-            textField.placeholder = "스티브 잡스"
+        // UserDefaults에 사용자 닉네임이 없으면, 닉네임을 받습니다.
+        if UserDefaults.standard.string(forKey: Constants.userDefaults_UserNickname) == nil {
+            
+            // UIAlertController 생성
+            let alertSetUserNickname:UIAlertController = UIAlertController(title: "닉네임 설정", message: "닉네임을 설정해주세요.", preferredStyle: .alert)
+            
+            // testField 추가
+            alertSetUserNickname.addTextField { (textField) in
+                textField.placeholder = "스티브 잡스"
+            }
+            
+            // OK 버튼 Action 추가
+            alertSetUserNickname.addAction(UIAlertAction(title: "OK", style: .default, handler: { [weak alertSetUserNickname] (_) in
+                
+                // 텍스트필드 호출
+                let textFieldNickname = alertSetUserNickname!.textFields![0] // 위에서 직접 추가한 텍스트필드이므로 옵셔널 바인딩은 스킵.
+                print("///// textField: ", textFieldNickname.text ?? "(no data)")
+                
+                // UserDefaults 에서 uid 호출 & 사용자가 텍스트필드에 입력한 텍스트 호출
+                guard let uid = UserDefaults.standard.string(forKey: Constants.userDefaults_Uid) else { return }
+                guard let userNickname = alertSetUserNickname!.textFields?[0].text else { return }
+                
+                let dicUserData:[String:Any] = [Constants.firebaseUserUid:uid, Constants.firebaseUserNickname:userNickname]
+                
+                // Firebase DB & UserDefaults에 저장
+                Database.database().reference().child(Constants.firebaseUsersRoot).child(uid).setValue(dicUserData)
+                UserDefaults.standard.set(userNickname, forKey: Constants.userDefaults_UserNickname)
+                
+                // 명언 댓글 뷰로 이동
+                // 닉네임이 있을 경우, 스토리보드 상에 선언된 show를 타서 이동합니다.
+                let nextVC = self.storyboard?.instantiateViewController(withIdentifier: Constants.quoteCommentViewController) as! QuoteCommentViewController
+                self.navigationController?.pushViewController(nextVC, animated: true)
+                
+            }))
+            
+            self.present(alertSetUserNickname, animated: true, completion: nil)
+            
         }
         
-        alertSetUserNickname.addAction(UIAlertAction(title: "OK", style: .default, handler: { [weak alertSetUserNickname] (_) in
-            let textField = alertSetUserNickname!.textFields![0] // 위에서 추가한 텍스트필드이므로 옵셔널 바인딩은 스킵.
-            print("///// textField: ", textField.text ?? "(no data)")
-        }))
         
-        self.present(alertSetUserNickname, animated: true, completion: nil)
+        
     }
-
+    
 }
 

--- a/QuoteDev/QuoteDev/QuoteCommentViewController.swift
+++ b/QuoteDev/QuoteDev/QuoteCommentViewController.swift
@@ -1,0 +1,35 @@
+//
+//  QuoteCommentViewController.swift
+//  QuoteDev
+//
+//  Created by leejaesung on 2017. 9. 20..
+//  Copyright © 2017년 leejaesung. All rights reserved.
+//
+
+import UIKit
+
+class QuoteCommentViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destinationViewController.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
## Firebase Auth SignIn
 - `AppDelegate`에서 구현하였습니다.
 - 앱을 실행시키면, 곧바로 익명 Auth를 가입시키고, `UserDefaults`에도 uid를 저장합니다.

## Firebase Database
 - `MainViewController.swift`에서 구현하였습니다.
 - 메인 뷰에서 댓글 버튼을 누르면, 닉네임을 입력하라는 `Alert`가 표시되고, 닉네임을 `Firebase`와 `UserDefaults`에 저장합니다.
 - 코드 가져다가 게시판에서 구현해 보세요.ㅋ

음.. 사족이지만, 댓글 버튼을 눌렀을 때, 구현하면 안되고, 댓글을 쓰고 싶을 때 구현하게 하려나요. 음음. 고민 중.

## Constants.swift
 - 상수들을 저장할 목적으로 `Constants.swift`를 만들었습니다.
 - 오타 방지 및 공동으로 사용되는 상수들을 함께 공유하고자 하기 위함입니다.
 - `Firebase`의 데이터베이스 키 값들도 여기서 참고하면 좋을 것 같아요. 😉 
 - `DataCenter`는 만들기만 하고, 아직 구현된 건 없습니다.

---

// 스크린샷
![simulator screen shot 2017 9 20 7 23 01](https://user-images.githubusercontent.com/28520038/30639278-2d6a5b60-9e39-11e7-951d-86b6d96d3cf7.png)
